### PR TITLE
fix issue with _updateIndexes

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -428,7 +428,7 @@ module.exports = function (mf) {
                         var out = this.prepJSON();
                         opts.db.put(this.key, out, acb);
                     }.bind(this),
-                    function (acb) {
+                    function (err, acb) {
                         //update indexes
                         if (mf.options.int_indexes.length || mf.options.bin_indexes.length) {
                             this._updateIndexes({bucket: opts.bucket, db: opts.db}, acb);


### PR DESCRIPTION
Callbacks weren't being fired because the previous step's `acb` was being passed direct to `opts.db.put` which caused the `err` value from it to pass as the first argument to next step
