### PR TITLE
Failing tests for `saveKey` illustrating #29.

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -951,6 +951,30 @@ module.exports = {
             });
         });
     },
+    "saveKey": function(test) {
+        var UserFactory = new dulcimer.Model({
+          firstName: {},
+          lastName: {},
+        }, {
+          name: 'user',
+          saveKey: true
+        });
+        
+        var john = UserFactory.create({
+            firstName: 'John',
+            lastName: 'Brett',
+        });
+        
+        john.save(function(err) {
+          UserFactory.all(function(err, users) {
+              users.forEach(function (user) {
+                  console.log(user.toJSON());
+                  test.ok('key' in user.toJSON());
+                  test.done();
+              });
+          });
+        });
+    },
     "Import stream": function (test) {
         var TM = new dulcimer.Model({
             first: {},


### PR DESCRIPTION
Hey I added a failing test for the `saveKey` issue but I'm not sure where the fix goes. I tried adding it in here like so: 

```
diff --git a/lib/base.js b/lib/base.js
index 1e3f781..038f5e1 100644
--- a/lib/base.js
+++ b/lib/base.js
@@ -322,6 +322,9 @@ module.exports = function (mf) {
                     delete out[fields[fidx]];
                 }
             }
+            if (mf.options.saveKey) {
+                out['key'] = 'random key'
+            }
             return out;
         },
```

but it didn't seem to end up in the results. Point me in the right direction @fritzy?
