### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Dulcimer
+# Dulcimer
 
 Dulcimer is an ORM for an embedded keystore in your Node.js app.
 The aim is to provide a consistent way of working with keystores that enables enjoyable development.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
